### PR TITLE
Make tables responsive and avoid breaking words in them

### DIFF
--- a/article.php
+++ b/article.php
@@ -199,7 +199,7 @@ function navbar($group, $current) {
 	echo '    <th class="nav">';
 
 	if ($current > 1) {
-		echo '     <a href="/' , $group , '/' , ($current-1) , '"><b>&laquo; previous</b></a>';
+		echo '     <a href="/' , $group , '/' , ($current-1) , '"><b>&laquo; <span>previous</span></b></a>';
 	} else {
 		echo '&nbsp;';
 	}
@@ -207,7 +207,7 @@ function navbar($group, $current) {
 	echo '    </th>' . "\n";
 	echo '    <th class="align-center">' . "$group (#$current)</th>\n";
 	echo '    <th class="nav align-right">';
-	echo '     <a href="/' , $group , '/' , ($current+1) , '"><b>next &raquo;</b></a>';
+	echo '     <a href="/' , $group , '/' , ($current+1) , '"><b><span>next</span> &raquo;</b></a>';
 	echo '    </th>' . "\n";
 	echo '   </tr>' . "\n";
 	echo '  </table>' . "\n";

--- a/group.php
+++ b/group.php
@@ -66,6 +66,7 @@ echo '</nav>';
 echo '<section class="content">';
 echo '<h1>'.htmlspecialchars($group, ENT_QUOTES, "UTF-8").'</h1>';
 navbar($group, $overview['group']['low'], $overview['group']['high'], $overview['group']['start']);
+echo ' <div class="responsive-table">' . "\n";
 echo '  <table class="standard">' . "\n";
 echo '   <tr>' . "\n";
 echo '    <th>#</th>' . "\n";
@@ -126,6 +127,7 @@ switch ($format) {
 	case 'html':
 	default:
 	echo "  </table>\n";
+	echo " </div>\n";
 	navbar($group, $overview['group']['low'], $overview['group']['high'], $overview['group']['start']);
 	echo "</section>";
 	foot();
@@ -137,7 +139,7 @@ function navbar($g, $f, $l, $i) {
 	echo '    <th class="nav">';
 	if ($i > $f) {
 		$p = max($i-20,$f);
-		echo "<a href=\"/" . htmlspecialchars($g, ENT_QUOTES, "UTF-8") . "/start/$p\"><b>&laquo; previous</b></a>";
+		echo "<a href=\"/" . htmlspecialchars($g, ENT_QUOTES, "UTF-8") . "/start/$p\"><b>&laquo; <span>previous</span></b></a>";
 	} else {
 		echo "&nbsp;";
 	}
@@ -148,7 +150,7 @@ function navbar($g, $f, $l, $i) {
 	echo '    <th class="nav align-right">';
 	if ($i+20 <= $l) {
 		$n = min($i + 20, $l - 19);
-		echo "<a href=\"/" . htmlspecialchars($g, ENT_QUOTES, "UTF-8") . "/start/$n\"><b>next &raquo;</b></a>";
+		echo "<a href=\"/" . htmlspecialchars($g, ENT_QUOTES, "UTF-8") . "/start/$n\"><b><span>next</span> &raquo;</b></a>";
 	}
 	else {
 		echo "&nbsp;";

--- a/style.css
+++ b/style.css
@@ -320,8 +320,7 @@ a.footer-nav-item-link:hover{
 /* Standard Tables */
 table.standard {
 	border-collapse: collapse;
-	border-style: hidden;
-	border:1px solid #d9d9d9;
+	border: 1px solid #d9d9d9;
 	width: 100%;
 	border-spacing:2px;
 }
@@ -364,6 +363,9 @@ table.standard th.subr {
 	text-align: right;
 }
 
+.responsive-table { overflow-x: scroll; }
+.responsive-table table { word-break: normal; }
+
 .align-right{
 	text-align: right;
 }
@@ -399,6 +401,13 @@ table.standard th.subr {
 }
 
 @media screen and (max-width: 580px) {
+	th.nav a {
+		font-size: 2rem;
+		text-decoration: none;
+	}
+	th.nav span {
+		display: none;
+	}
 	.menu-icon{
 		display: block;
 	}


### PR DESCRIPTION
Hide "previous" / "next" labels in small devices and enlarge the navigation arrows
Make the group.php table responsive and avoid breaking words in table cells