### PR TITLE
Use foreach instead of each and check if $filter is null

### DIFF
--- a/article.php
+++ b/article.php
@@ -176,7 +176,7 @@ function start_article($mail, $refsResolved) {
 		echo '     <td class="headerlabel">Groups:</td>' . "\n";
 		echo '     <td class="headervalue" '.(empty($refsResolved) ? 'colspan="3"' : null).'>';
 		$r = explode(",", rtrim($mail['headers']['newsgroups']));
-		while (list($k,$v) = each($r)) {
+		foreach ($r as $v) {
 			echo "<a href=\"/".urlencode($v)."\">".htmlspecialchars($v)."</a>&nbsp;";
 		}
 		echo "</td>\n";

--- a/lib/fMailbox.php
+++ b/lib/fMailbox.php
@@ -348,7 +348,7 @@ class fMailbox
 		$multi_email_fields     = array('to', 'cc');
 		$additional_info_fields = array('content-type', 'content-disposition');
 
-		$parsedHeaders = array();
+		$parsed_headers = array();
 		foreach ($header_lines as $header_line) {
 			$header_line = preg_replace("#\r\n\s+#", ' ', $header_line);
 			$header_line = trim($header_line);
@@ -368,7 +368,7 @@ class fMailbox
 				$pieces = preg_split('#;\s*#', $value, 2);
 				$value = $pieces[0];
 
-				$parsedHeaders[$header] = array('value' => self::decodeHeader($value));
+				$parsed_headers[$header] = array('value' => self::decodeHeader($value));
 
 				$fields = array();
 				if (!empty($pieces[1])) {
@@ -377,10 +377,10 @@ class fMailbox
 						$fields[strtolower($match[1])] = self::decodeHeader(!empty($match[4]) ? $match[4] : $match[3]);
 					}
 				}
-				$parsedHeaders[$header]['fields'] = $fields;
+				$parsed_headers[$header]['fields'] = $fields;
 
 			} elseif ($is_single_email) {
-				$parsedHeaders[$header] = self::parseEmail($value);
+				$parsed_headers[$header] = self::parseEmail($value);
 
 			} elseif ($is_multi_email) {
 				$strings = array();
@@ -407,26 +407,26 @@ class fMailbox
 					);
 				}
 
-				$parsedHeaders[$header] = array();
+				$parsed_headers[$header] = array();
 				foreach ($emails as $email) {
-					$parsedHeaders[$header][] = self::parseEmail($email);
+					$parsed_headers[$header][] = self::parseEmail($email);
 				}
 
 			} elseif ($header == 'references') {
-				$parsedHeaders[$header] = array_map(array('fMailbox', 'decodeHeader'), preg_split('#(?<=>)\s+(?=<)#', $value));
+				$parsed_headers[$header] = array_map(array('fMailbox', 'decodeHeader'), preg_split('#(?<=>)\s+(?=<)#', $value));
 
 			} elseif ($header == 'received') {
-				if (!isset($parsedHeaders[$header])) {
-					$parsedHeaders[$header] = array();
+				if (!isset($parsed_headers[$header])) {
+					$parsed_headers[$header] = array();
 				}
-				$parsedHeaders[$header][] = preg_replace('#\s+#', ' ', self::decodeHeader($value));
+				$parsed_headers[$header][] = preg_replace('#\s+#', ' ', self::decodeHeader($value));
 
 			} else {
-				$parsedHeaders[$header] = self::decodeHeader($value);
+				$parsed_headers[$header] = self::decodeHeader($value);
 			}
 		}
 
-		return $parsedHeaders;
+		return $parsed_headers;
 	}
 
 	/**

--- a/lib/fMailbox.php
+++ b/lib/fMailbox.php
@@ -348,7 +348,7 @@ class fMailbox
 		$multi_email_fields     = array('to', 'cc');
 		$additional_info_fields = array('content-type', 'content-disposition');
 
-		$headers = array();
+		$parsedHeaders = array();
 		foreach ($header_lines as $header_line) {
 			$header_line = preg_replace("#\r\n\s+#", ' ', $header_line);
 			$header_line = trim($header_line);
@@ -368,7 +368,7 @@ class fMailbox
 				$pieces = preg_split('#;\s*#', $value, 2);
 				$value = $pieces[0];
 
-				$headers[$header] = array('value' => self::decodeHeader($value));
+				$parsedHeaders[$header] = array('value' => self::decodeHeader($value));
 
 				$fields = array();
 				if (!empty($pieces[1])) {
@@ -377,10 +377,10 @@ class fMailbox
 						$fields[strtolower($match[1])] = self::decodeHeader(!empty($match[4]) ? $match[4] : $match[3]);
 					}
 				}
-				$headers[$header]['fields'] = $fields;
+				$parsedHeaders[$header]['fields'] = $fields;
 
 			} elseif ($is_single_email) {
-				$headers[$header] = self::parseEmail($value);
+				$parsedHeaders[$header] = self::parseEmail($value);
 
 			} elseif ($is_multi_email) {
 				$strings = array();
@@ -407,26 +407,26 @@ class fMailbox
 					);
 				}
 
-				$headers[$header] = array();
+				$parsedHeaders[$header] = array();
 				foreach ($emails as $email) {
-					$headers[$header][] = self::parseEmail($email);
+					$parsedHeaders[$header][] = self::parseEmail($email);
 				}
 
 			} elseif ($header == 'references') {
-				$headers[$header] = array_map(array('fMailbox', 'decodeHeader'), preg_split('#(?<=>)\s+(?=<)#', $value));
+				$parsedHeaders[$header] = array_map(array('fMailbox', 'decodeHeader'), preg_split('#(?<=>)\s+(?=<)#', $value));
 
 			} elseif ($header == 'received') {
-				if (!isset($headers[$header])) {
-					$headers[$header] = array();
+				if (!isset($parsedHeaders[$header])) {
+					$parsedHeaders[$header] = array();
 				}
-				$headers[$header][] = preg_replace('#\s+#', ' ', self::decodeHeader($value));
+				$parsedHeaders[$header][] = preg_replace('#\s+#', ' ', self::decodeHeader($value));
 
 			} else {
-				$headers[$header] = self::decodeHeader($value);
+				$parsedHeaders[$header] = self::decodeHeader($value);
 			}
 		}
 
-		return $headers;
+		return $parsedHeaders;
 	}
 
 	/**

--- a/lib/fMailbox.php
+++ b/lib/fMailbox.php
@@ -356,7 +356,7 @@ class fMailbox
 			list ($header, $value) = preg_split('#:\s*#', $header_line, 2);
 			$header = strtolower($header);
 
-			if (strpos($header, $filter) !== false) {
+			if ($filter !== null && strpos($header, $filter) !== false) {
 				continue;
 			}
 


### PR DESCRIPTION
This PR fixes two issues hindering running this locally on PHP 8:

1. The use of `each()`, since `each()` no longer exists
2. Passing `null` into `strpos()` in PHP 8 treats it as an empty string

(I used to have karma for web-news, but I don't seem to have access to directly commit or merge anything now.)