### PR TITLE
Show the correct NNTP hostname, which may not be the HTTP host

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,8 +25,8 @@ head();
    <h1>PHP Mailing Lists</h1>
    <p>
     This is a completely experimental interface to the PHP mailing lists as
-    reflected on the <a href="news://<?php echo htmlspecialchars($_SERVER['HTTP_HOST'],ENT_QUOTES,"UTF-8"); ?>/">
-    <?php echo htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES, "UTF-8"); ?> NNTP server</a>.
+    reflected on the <a href="news://<?php echo htmlspecialchars(NNTP_HOST,ENT_QUOTES,"UTF-8"); ?>/">
+    <?php echo htmlspecialchars(NNTP_HOST, ENT_QUOTES, "UTF-8"); ?> NNTP server</a>.
     The news server software that is used is <a
       href="https://trainedmonkey.com/projects/colobus/">colobus</a>.
    </p>


### PR DESCRIPTION
Just giving out bad info, we are