### PR TITLE
Do some very simple handling of text/html-only messages (fixes #23)

### DIFF
--- a/article.php
+++ b/article.php
@@ -129,7 +129,9 @@ if (!array_key_exists('text', $mail)) {
          * should be totally safe because all of the text get re-encoded
          * later.
          */
-        $mail['text'] = html_entity_decode(strip_tags($mail['html']), encoding: 'UTF-8');
+        // This makes HTML from Apple's Mail app retain paragraph breaks
+        $text = preg_replace('#<div><br></div>#', "\n\n", $mail['html']);
+        $mail['text'] = html_entity_decode(strip_tags($text), encoding: 'UTF-8');
     } else {
         $mail['text'] = "> There was no text content in this message.";
     }

--- a/article.php
+++ b/article.php
@@ -131,6 +131,8 @@ if (!array_key_exists('text', $mail)) {
          */
         // This makes HTML from Apple's Mail app retain paragraph breaks
         $text = preg_replace('#<div><br></div>#', "\n\n", $mail['html']);
+        // And this avoids extra linebreaks from another example (Android?)
+        $text = preg_replace("#\n<br>\n#", "\n", $mail['html']);
         $mail['text'] = html_entity_decode(strip_tags($text), encoding: 'UTF-8');
     } else {
         $mail['text'] = "> There was no text content in this message.";

--- a/article.php
+++ b/article.php
@@ -116,6 +116,25 @@ echo "  </blockquote>\n";
 echo "  <blockquote>\n";
 echo "   <pre>\n";
 
+/*
+ * If there was no text part of the message, see what we can do about creating
+ * one from a text/html part, or just inject a note that there was no text to
+ * avoid further errors.
+ */
+if (!array_key_exists('text', $mail)) {
+    if (array_key_exists('html', $mail)) {
+        /*
+         * This just aggressively strips out all tags. For the examples at
+         * hand, this looked okay-ish. Better than nothing, at least, and
+         * should be totally safe because all of the text get re-encoded
+         * later.
+         */
+        $mail['text'] = html_entity_decode(strip_tags($mail['html']), encoding: 'UTF-8');
+    } else {
+        $mail['text'] = "> There was no text content in this message.";
+    }
+}
+
 $lines = preg_split("@(?<=\r\n|\n)@", $mail['text']);
 $insig = $is_commit = $is_diff = 0;
 


### PR DESCRIPTION
Started going down the path of doing more to make the converted text more presentable, but these messages are few and far between right now, so the blunt method seems fine.