### PR TITLE
Handle format=flowed messages

### DIFF
--- a/lib/fMailbox.php
+++ b/lib/fMailbox.php
@@ -189,8 +189,12 @@ class Mailbox
 
 
         $has_disposition = !empty($structure['disposition']);
-        $is_text         = $structure['type'] == 'text' && $structure['subtype'] == 'plain';
         $is_html         = $structure['type'] == 'text' && $structure['subtype'] == 'html';
+        $is_text         = $structure['type'] == 'text' && $structure['subtype'] == 'plain';
+        if ($is_text) {
+            $info['flowed']  = strtolower($structure['type_fields']['format'] ?? "") == 'flowed';
+            $info['delsp']   = strtolower($structure['type_fields']['delsp'] ?? "") == 'yes';
+        }
 
         // If the part doesn't have a disposition and is not the default text or html, set the disposition to inline
         if (!$has_disposition && ((!$is_text || !empty($info['text'])) && (!$is_html || !empty($info['html'])))) {

--- a/style.css
+++ b/style.css
@@ -370,6 +370,29 @@ table.standard th.subr {
 .quote3 { color: #a36008; }
 .quote0 { color: #909; }
 
+pre.flowed {
+    max-width: 100ch;
+    font-family: "Fira Sans", "Source Sans Pro", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+}
+pre.flowed code, pre.flowed pre {
+    font-weight: 700;
+    color: #369;
+}
+pre.flowed pre {
+    background: rgba(0,0,0,0.05);
+    border: 1px solid rgba(0,0,0,0.2);
+    padding: 0.5rem;
+    margin: 0;
+}
+
+div.quote {
+    border-left: 2px solid #777;
+    padding: 0;
+    padding-left: 1em;
+    margin: 0;
+}
+
 /* Highlight of diffs in commit messages */
 .added   { color: #000099; }
 .removed { color: #990000; }


### PR DESCRIPTION
When the `text/plain` part has the `flowed` format, we can be a little more clever about how we transform the message into HTML.

 * Switch to non-monospace font and let long lines wrap naturally
 * Handle quotes as blocks with side-border
 * Handle indented and triple-tick code blocks

This also fixes handling of links, including Markdown-style, and adds handling of inline Markdown-style code blocks