### PR TITLE
Display thread tree as a tree

### DIFF
--- a/article.php
+++ b/article.php
@@ -274,5 +274,26 @@ echo '    </th>' . "\n";
 echo '   </tr>' . "\n";
 echo '  </table>' . "\n";
 echo '</section>';
+?>
+<script>
+    function localizeTimeElements() {
+      const timeElements = document.querySelectorAll('time[datetime]');
+
+      timeElements.forEach(timeElement => {
+        const iso8601String = timeElement.getAttribute('datetime');
+        const date = new Date(iso8601String);
+
+        if (!isNaN(date.getTime())) { // Check if the date is valid
+          timeElement.textContent = date.toLocaleString();
+        } else {
+          console.error(`Invalid datetime attribute: ${iso8601String}`);
+        }
+      });
+    }
+
+    // Call the function when the DOM is loaded
+    document.addEventListener('DOMContentLoaded', localizeTimeElements);
+</script>
+<?
 
 foot();

--- a/article.php
+++ b/article.php
@@ -274,26 +274,5 @@ echo '    </th>' . "\n";
 echo '   </tr>' . "\n";
 echo '  </table>' . "\n";
 echo '</section>';
-?>
-<script>
-    function localizeTimeElements() {
-      const timeElements = document.querySelectorAll('time[datetime]');
-
-      timeElements.forEach(timeElement => {
-        const iso8601String = timeElement.getAttribute('datetime');
-        const date = new Date(iso8601String);
-
-        if (!isNaN(date.getTime())) { // Check if the date is valid
-          timeElement.textContent = date.toLocaleString();
-        } else {
-          console.error(`Invalid datetime attribute: ${iso8601String}`);
-        }
-      });
-    }
-
-    // Call the function when the DOM is loaded
-    document.addEventListener('DOMContentLoaded', localizeTimeElements);
-</script>
-<?
 
 foot();

--- a/article.php
+++ b/article.php
@@ -244,21 +244,7 @@ try {
         <h2>
           Thread (<?= sprintf("%d message%s", $count = $threads->count(), $count > 1 ? 's' : '') ?>)
         </h2>
-        <div class="responsive-table">
-          <table class="standard">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Subject</th>
-                <th>Author</th>
-                <th>Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              <?php $threads->printRows($group, 'utf8'); ?>
-            </tbody>
-          </table>
-        </div>
+        <?php $threads->printFullThread($group, $article, charset: 'utf8'); ?>
       </blockquote>
     <?php
 } catch (\Throwable $t) {

--- a/lib/ThreadTree.php
+++ b/lib/ThreadTree.php
@@ -155,7 +155,9 @@ class ThreadTree
                 format_author($details['author'], $charset, nameOnly: true),
                 '</span>',
                 '<span class="date">',
+                '<time datetime="', format_date($details['date'], 'c'), '">',
                 format_date($details['date'], "D, j M Y H:i"),
+                '</time>',
                 '</span>';
 
             $newSubject = format_subject($details['subject'], $charset, trimRe: true);

--- a/lib/ThreadTree.php
+++ b/lib/ThreadTree.php
@@ -151,13 +151,18 @@ class ThreadTree
                 echo "<b>";
             }
             echo
+                '<span class="author">',
                 format_author($details['author'], $charset, nameOnly: true),
-                " &mdash; ",
-                format_date($details['date'], "F j, Y, g:i a");
+                '</span>',
+                '<span class="date">',
+                format_date($details['date'], "D, j M Y H:i"),
+                '</span>';
 
             $newSubject = format_subject($details['subject'], $charset, trimRe: true);
-            if ($newSubject != $subject) {
-                echo " &mdash; " . format_subject($details['subject'], $charset);
+            if ($messageId != $this->root && $newSubject != $subject) {
+                echo '<span class="subject">';
+                echo format_subject($details['subject'], $charset);
+                echo '</span>';
             }
 
             if ($articleNumber != $activeArticleNumber) {
@@ -181,8 +186,7 @@ class ThreadTree
                 echo '</ul>';
             }
 
+            echo "</li>";
         }
-
-        echo "</li>";
     }
 }

--- a/lib/ThreadTree.php
+++ b/lib/ThreadTree.php
@@ -156,7 +156,7 @@ class ThreadTree
                 '</span>',
                 '<span class="date">',
                 '<time datetime="', format_date($details['date'], 'c'), '">',
-                format_date($details['date'], "D, j M Y H:i"),
+                format_date($details['date']),
                 '</time>',
                 '</span>';
 

--- a/lib/common.php
+++ b/lib/common.php
@@ -270,7 +270,7 @@ function format_subject($s, $charset = 'iso-8859-1', $trimRe = false)
     $s = recode_header($s, $charset);
 
     /* Trim most of the prefixes we add for lists */
-    $s = preg_replace('/^(Re:\s*)?(\s*\[(DOC|PEAR|PECL|PHP|ANNOUNCE|GIT-PULLS|STANDARDS|php-standards)(-.+?)?]\s*)+/i', $trimRe ? '' : '\1', $s);
+    $s = preg_replace('/^(Re:\s*)?(\s*\[(DOC|PEAR|PECL|PHP|ANNOUNCE|GIT-PULLS|STANDARDS|php-standards)(-.+?)?]\s*(Re:\s*)?)+/', $trimRe ? '' : '\1\5', $s);
 
     // make this look better on the preview page..
     if (strlen($s) > 150 && !isset($article)) {

--- a/style.css
+++ b/style.css
@@ -387,6 +387,68 @@ form.subscription-form {
     gap: 1em;
 }
 
+/* Thread tree, based on: https://www.cssscript.com/tree-view-unlimited-nesting/ */
+.list-tree {
+  --tree-clr: #075985;
+  --tree-font-size: 1rem;
+  --tree-item-height: 1.5;
+  --tree-offset: 0.5rem;
+  --tree-indent: 0.5rem;
+  --tree-thickness: 1px;
+  --tree-style: solid;
+}
+.list-tree ul{
+  display: grid;
+  list-style: none;
+  font-size: var(--tree-font-size);
+  padding-inline-start: var(--tree-indent);
+}
+.list-tree li{
+  line-height: var(--tree-item-height);
+  padding-inline-start: var(--tree-offset);
+  border-left: var(--tree-thickness) var(--tree-style) var(--tree-clr);
+  position: relative;
+  text-indent: .5rem;
+
+  &:last-child {
+    border-color: transparent; /* hide (not remove!) border on last li element*/
+  }
+  & span{
+    font-size: 0.8rem;
+    font-style: italic;
+    font-weight: 100;
+    opacity: .65;
+
+  }
+  &::before{
+    content: '';
+    position: absolute;
+    top: calc(var(--tree-font-size) / 2 + var(--tree-item-height) / 2 * -1 * var(--tree-font-size) + var(--tree-thickness));
+    left: calc(var(--tree-thickness) * -1);
+    width: calc(var(--tree-offset) + var(--tree-thickness) * 2);
+    height: calc(var(--tree-item-height)  * var(--tree-font-size) - var(--tree-font-size) / 2);
+    border-left: var(--tree-thickness) var(--tree-style) var(--tree-clr);
+    border-bottom: var(--tree-thickness) var(--tree-style) var(--tree-clr);
+  }
+  &::after{
+    content: '';
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--tree-clr);
+    top: calc(var(--tree-item-height) / 2 * 1rem);
+    left: var(--tree-offset) ;
+    translate: calc(var(--tree-thickness) * -1) calc(var(--tree-thickness) * -1);
+  }
+  & li li{
+    /*
+    change line color etc.
+    --tree-clr: rgb(175, 208, 84);
+    */
+  }
+}
+
 @media screen and (max-width: 760px) {
     .welcome {
         display: none;

--- a/style.css
+++ b/style.css
@@ -402,6 +402,7 @@ form.subscription-form {
   list-style: none;
   font-size: var(--tree-font-size);
   padding-inline-start: var(--tree-indent);
+  max-width: 50em;
 }
 .list-tree li{
   line-height: var(--tree-item-height);
@@ -413,12 +414,24 @@ form.subscription-form {
   &:last-child {
     border-color: transparent; /* hide (not remove!) border on last li element*/
   }
-  & span{
-    font-size: 0.8rem;
-    font-style: italic;
-    font-weight: 100;
-    opacity: .65;
 
+  & a, & b {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      align-item: start;
+      & span.author {
+        grid-column: 1 / 1;
+        white-space: normal;
+      }
+      & span.date {
+        grid-column: 2 / 2;
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
+      }
+      & span.subject {
+        grid-column: 1 / 2;
+        white-space: normal;
+      }
   }
   &::before{
     content: '';


### PR DESCRIPTION
[Before](https://news-web.php.net/php.internals/126779):
![Screenshot 2025-03-23 at 11 52 51 AM](https://github.com/user-attachments/assets/9effd9e2-c7ec-42be-bdc9-2e4d7eee488b)

After:
![Screenshot 2025-03-23 at 11 53 04 AM](https://github.com/user-attachments/assets/3355d468-1fbf-40f3-af60-a9d9835b8377)

The message being viewed is too far down in the thread to be seen in the screenshot, but the current message is in bold and not a link so the context is clear.