### PR TITLE
Fix handling of missing parent messages in `ThreadTree`

### DIFF
--- a/lib/ThreadTree.php
+++ b/lib/ThreadTree.php
@@ -133,16 +133,14 @@ class ThreadTree
             return;
         }
 
+
+        # for debugging that we've actually handled all articles
+        #unset($this->articleNumbers[$messageId]);
+
+        echo '<li>';
+
         if (array_key_exists($messageId, $this->articleNumbers)) {
             $articleNumber = $this->articleNumbers[$messageId];
-
-            # for debugging that we've actually handled all articles
-            #unset($this->articleNumbers[$messageId]);
-
-            $details = $this->articles[$articleNumber];
-
-            echo '<li>';
-
             $details = $this->articles[$articleNumber];
 
             if ($articleNumber != $activeArticleNumber) {
@@ -172,23 +170,26 @@ class ThreadTree
             } else {
                 echo "</b>";
             }
-
-            if (array_key_exists($messageId, $this->tree)) {
-                echo '<ul>';
-                foreach ($this->tree[$messageId] as $childMessageId) {
-                    $this->printThread(
-                        group: $group,
-                        activeArticleNumber: $activeArticleNumber,
-                        messageId: $childMessageId,
-                        subject: $newSubject,
-                        charset: $charset,
-                        depth: $depth + 1,
-                    );
-                }
-                echo '</ul>';
-            }
-
-            echo "</li>";
+        } else {
+            echo "<i>Unknown Message</i>";
+            $newSubject = $messageId;
         }
+
+        if (array_key_exists($messageId, $this->tree)) {
+            echo '<ul>';
+            foreach ($this->tree[$messageId] as $childMessageId) {
+                $this->printThread(
+                    group: $group,
+                    activeArticleNumber: $activeArticleNumber,
+                    messageId: $childMessageId,
+                    subject: $newSubject,
+                    charset: $charset,
+                    depth: $depth + 1,
+                );
+            }
+            echo '</ul>';
+        }
+
+        echo "</li>";
     }
 }


### PR DESCRIPTION
The logic to correctly associate messages where the parent message is not in the archives already existed by means of `ThreadTree::$extraRootChildren`, however the “extra root” threads were not correctly printed, because `printThread()` required the message at the root of the thread to exist.

Fix this by printing a placeholder “Unknown message” for unknown messageIds and then printing the children as usual.

Fixes php/web-news#35

------------


<img width="802" height="149" alt="image" src="https://github.com/user-attachments/assets/1305baba-195b-4d90-9eff-503c651e368e" />
