### PR TITLE
File-Based Cache for NNTP Data

### DIFF
--- a/article.php
+++ b/article.php
@@ -17,7 +17,7 @@ if (isset($_GET['group'])) {
 
 $nntpClient = new \Web\News\Nntp($NNTP_HOST);
 
-$articleInfo = memo(
+['mail' => $mail, 'refsResolved' => $refsResolved] = memo(
     "article:{$group}/{$article}",
     TTL_ARTICLE_CONTENT, // permanent cache
     function() use ($article, $group, $nntpClient) {
@@ -64,15 +64,9 @@ $articleInfo = memo(
             error($e->getMessage());
         }
 
-        return [ 'mail' => $mail, 'refsResolved' => $refsResolved, 'references' => $references ];
+        return [ 'mail' => $mail, 'refsResolved' => $refsResolved ];
     },
 );
-
-[
-    'mail' => $mail,
-    'refsResolved' => $refsResolved,
-    'references' => $references,
-] = $articleInfo;
 
 head("{$group}: " . format_title($mail['headers']['subject'], 'utf-8'));
 echo '<nav class="secondary-nav">';

--- a/article.php
+++ b/article.php
@@ -15,49 +15,64 @@ if (isset($_GET['group'])) {
     $group = false;
 }
 
-try {
-    $nntpClient = new \Web\News\Nntp($NNTP_HOST);
-    $message = $nntpClient->readArticle($article, $group);
+$nntpClient = new \Web\News\Nntp($NNTP_HOST);
 
-    if ($message === null) {
-        error('No article found');
-    }
+$articleInfo = memo(
+    "article:{$group}/{$article}",
+    TTL_ARTICLE_CONTENT, // permanent cache
+    function() use ($article, $group, $nntpClient) {
+        try {
+            $message = $nntpClient->readArticle($article, $group);
 
-    $mail = \Flourish\Mailbox::parseMessage($message);
-
-    $rawReferences = [];
-    if (!empty($mail['headers']['references'])) {
-        $rawReferences = $mail['headers']['references'];
-    } elseif (!empty($mail['headers']['in-reply-to'])) {
-        $rawReferences = $mail['headers']['in-reply-to'];
-    }
-
-    $references = [];
-    foreach ($rawReferences as $ref) {
-        $matches = [];
-        if (preg_match_all('/\<(.*?)\>/', $ref, $matches)) {
-            foreach ($matches[0] as $match) {
-                $references[] = $match;
+            if ($message === null) {
+                error('No article found');
             }
-        }
-    }
 
-    $refsResolved = [];
+            $mail = \Flourish\Mailbox::parseMessage($message);
 
-    $refCount = 0;
-    foreach ($references as $messageId) {
-        if (!$messageId) {
-            continue;
+            $rawReferences = [];
+            if (!empty($mail['headers']['references'])) {
+                $rawReferences = $mail['headers']['references'];
+            } elseif (!empty($mail['headers']['in-reply-to'])) {
+                $rawReferences = $mail['headers']['in-reply-to'];
+            }
+
+            $references = [];
+            foreach ($rawReferences as $ref) {
+                $matches = [];
+                if (preg_match_all('/\<(.*?)\>/', $ref, $matches)) {
+                    foreach ($matches[0] as $match) {
+                        $references[] = $match;
+                    }
+                }
+            }
+
+            $refsResolved = [];
+
+            $refCount = 0;
+            foreach ($references as $messageId) {
+                if (!$messageId) {
+                    continue;
+                }
+                if ($refCount >= REFERENCES_LIMIT) {
+                    break;
+                }
+                $refsResolved[] = $nntpClient->xpath($messageId);
+                $refCount++;
+            }
+        } catch (Exception $e) {
+            error($e->getMessage());
         }
-        if ($refCount >= REFERENCES_LIMIT) {
-            break;
-        }
-        $refsResolved[] = $nntpClient->xpath($messageId);
-        $refCount++;
-    }
-} catch (Exception $e) {
-    error($e->getMessage());
-}
+
+        return [ 'mail' => $mail, 'refsResolved' => $refsResolved, 'references' => $references ];
+    },
+);
+
+[
+    'mail' => $mail,
+    'refsResolved' => $refsResolved,
+    'references' => $references,
+] = $articleInfo;
 
 head("{$group}: " . format_title($mail['headers']['subject'], 'utf-8'));
 echo '<nav class="secondary-nav">';
@@ -363,7 +378,11 @@ echo "   </pre>\n";
 echo "  </blockquote>\n";
 
 try {
-    $overview = $nntpClient->getThreadOverview($group, $article);
+    $overview = memo(
+        "threads:{$group}/{$article}/overview",
+        TTL_THREAD_META,
+        fn() => $nntpClient->getThreadOverview($group, $article),
+    );
 
     $threads = new \PhpWeb\ThreadTree($overview['articles']);
     ?>

--- a/group.php
+++ b/group.php
@@ -22,9 +22,9 @@ if (isset($_GET['i'])) {
     $i = 0;
 }
 
+$nntpClient = new \Web\News\Nntp($NNTP_HOST);
 try {
-    $nntpClient = new \Web\News\Nntp($NNTP_HOST);
-    $overview = $nntpClient->getArticlesOverview($group, $i);
+    $overview = memo("articles-overview:{$group}/p{$i}", TTL_THREAD_META, fn() => $nntpClient->getArticlesOverview($group, $i));
 } catch (Exception $e) {
     error($e->getMessage());
 }
@@ -71,7 +71,7 @@ switch ($format) {
         echo '<h1>' . htmlspecialchars($group, ENT_QUOTES, "UTF-8") . '</h1>';
         if ($i == 0) {
             /* Special header of info for the main page for a group */
-            $groups = $nntpClient->listGroups($group);
+            $groups = memo("group:{$group}/list", TTL_THREAD_META, fn() => $nntpClient->listGroups($group));
 
             if ($groups[$group]['status'] == 'n') {
                 ?>

--- a/index.php
+++ b/index.php
@@ -2,10 +2,12 @@
 
 require 'common.php';
 
+$DATA_TTL = 600;
+
 try {
     $nntpClient = new \Web\News\Nntp($NNTP_HOST);
-    $groups = $nntpClient->listGroups();
-    $descriptions = $nntpClient->listGroupDescriptions();
+    $groups = memo('groups:list', $DATA_TTL, fn() => $nntpClient->listGroups());
+    $descriptions = memo('groups:descriptions', $DATA_TTL, fn() => $nntpClient->listGroupDescriptions());
     /* Reorder so it's moderated, active, and inactive */
     $order = [ 'm' => 1, 'y' => 2, 'n' => 3 ];
     uasort($groups, function ($a, $b) use ($order) {

--- a/lib/Web/News/Nntp.php
+++ b/lib/Web/News/Nntp.php
@@ -12,6 +12,9 @@ class Nntp
      */
     protected $connection;
 
+    private $hostname;
+    private $port;
+
     /**
      * Constructs an Nntp object
      *
@@ -20,8 +23,18 @@ class Nntp
      */
     public function __construct($hostname, $port = 119)
     {
+        $this->hostname = $hostname;
+        $this->port = $port;
+    }
+
+    private function connect(): self
+    {
+        if ($this->connection) {
+            return $this;
+        }
+
         $errno = $errstr = null;
-        $this->connection = @fsockopen($hostname, $port, $errno, $errstr, 30);
+        $this->connection = @fsockopen($this->hostname, $this->port, $errno, $errstr, 30);
 
         if (!$this->connection) {
             throw new \RuntimeException(
@@ -43,6 +56,8 @@ class Nntp
                 // Successful connection
                 break;
         }
+
+        return $this;
     }
 
     /**
@@ -50,6 +65,10 @@ class Nntp
      */
     public function __destruct()
     {
+        if (!$this->connection) {
+            return;
+        }
+
         $this->sendCommand('QUIT', 205);
         fclose($this->connection);
         $this->connection = null;
@@ -72,7 +91,7 @@ class Nntp
                 }
 
                 $line = rtrim($line);
-                list($group, $high, $low, $status) = explode(' ', $line);
+                [$group, $high, $low, $status] = explode(' ', $line);
 
                 $list[$group] = [
                     'high' => $high,
@@ -104,7 +123,7 @@ class Nntp
                 }
 
                 $line = rtrim($line);
-                list($group, $description) = explode(' ', $line, 2);
+                [$group, $description] = explode(' ', $line, 2);
 
                 $list[$group] = $description;
             }
@@ -125,7 +144,7 @@ class Nntp
         $response = $this->sendCommand("GROUP {$group}", 211);
 
         if ($response !== false) {
-            list($number, $low, $high, $group) = explode(' ', $response);
+            [$number, $low, $high, $group] = explode(' ', $response);
 
             return [
                 'group' => $group,
@@ -173,7 +192,7 @@ class Nntp
             }
 
             $line = rtrim($line);
-            list($n, $subject, $author, $date, $messageId, $references, $lines, $extra) = explode("\t", $line, 9);
+            [$n, $subject, $author, $date, $messageId, $references, $lines, $extra] = explode("\t", $line, 9);
 
             $overview['articles'][$n] = [
                 'subject' => $subject,
@@ -214,7 +233,7 @@ class Nntp
             }
 
             $line = rtrim($line);
-            list($n, $subject, $author, $date, $messageId, $references, $lines, $extra) = explode("\t", $line, 9);
+            [$n, $subject, $author, $date, $messageId, $references, $lines, $extra] = explode("\t", $line, 9);
 
             $overview['articles'][$n] = [
                 'subject' => $subject,
@@ -272,7 +291,7 @@ class Nntp
     public function xpath($messageId)
     {
         $response = $this->sendCommand("XPATH {$messageId}", 223);
-        list($group, $articleId) = explode('/', $response);
+        [$group, $articleId] = explode('/', $response);
 
         return [
             'messageId' => $messageId,
@@ -290,9 +309,11 @@ class Nntp
      */
     protected function sendCommand($command, $expected)
     {
+        $this->connect();
+
         fwrite($this->connection, "$command\r\n");
         $result = fgets($this->connection);
-        list($code, $response) = explode(' ', $result, 2);
+        [$code, $response] = explode(' ', $result, 2);
 
         if ($code == $expected) {
             return rtrim($response);

--- a/lib/common.php
+++ b/lib/common.php
@@ -342,3 +342,43 @@ function get_subscribe_address($group, $mode = '')
 {
     return get_list_address($group) . '+subscribe' . ($mode ? '-' . $mode : '') . '@lists.php.net';
 }
+
+function memo(string $key, int $refreshAfter, Closure $callback): mixed
+{
+    $cacheKey = sha1($key);
+
+    // as this may have thousands of files, they're broken down into nested directories
+    $cacheDir = ($_ENV['CACHE_DIR'] ?? (__DIR__ . '/../.cache')) . '/' . substr($cacheKey, 0, 2);
+    if (!is_dir($cacheDir)) {
+        mkdir($cacheDir, recursive: true);
+    }
+
+    // note: uses unserialize to avoid empty array ambiguity issues, it is recommended to set CACHE_DIR
+    // to somewhere that can only be written to by this process
+    $cachePath = $cacheDir . '/' . $cacheKey;
+    if (file_exists($cachePath) && ($refreshAfter == -1 || (filemtime($cachePath) > time() - $refreshAfter))) {
+        $fp = fopen($cachePath, 'r');
+        $data = null;
+        if ($fp && flock($fp, LOCK_SH)) {
+            $data = stream_get_contents($fp);
+            flock($fp, LOCK_UN);
+        }
+
+        if ($fp) {
+            fclose($fp);
+        }
+
+        if ($data !== null && $data !== false) {
+            return unserialize($data);
+        }
+    }
+
+    $result = $callback();
+    @file_put_contents($cachePath, serialize($result), LOCK_EX);
+
+    return $result;
+}
+
+define('TTL_ARTICLE_CONTENT', -1);
+define('TTL_THREAD_META', 120);
+define('TTL_GROUPS', 3600);


### PR DESCRIPTION
Enormously improves performance by:

- Lazy-loading the connection to the NNTP server. Now it only makes the connection when the first command is made.
- Using server-side file-based cache

Caches the following:
- Groups and Descriptions for 1 hour - Mainly only needed for the message count.
- Message content indefinitely, including paths of resolved references - These should be completely immutable unless the server is significantly reconfigured.
- Message metadata (descendent messages etc) for 2 minutes - Needed to show new / related posts

Not covered:
- Locking while populating cache key
