### PR TITLE
Canonicalises feed base URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ for local development.
 ```
 git clone https://github.com/php/web-news.git
 cd web-news/
-NNTP_HOST=news.php.net php -S localhost:8080 .router.php
+NNTP_HOST=news-web.php.net php -S localhost:8080 .router.php
 ```
 
 -----

--- a/group.php
+++ b/group.php
@@ -29,15 +29,18 @@ try {
     error($e->getMessage());
 }
 
-$host = htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES, "UTF-8");
+$cleanBaseUrl = clean($NEWS_WEB_BASE_URL);
+$baseUrlParts = parse_url($NEWS_WEB_BASE_URL);
+$cleanBaseHost = clean($baseUrlParts['host'] . (isset($baseUrlParts['port']) ? ':' . $baseUrlParts['port'] : ''));
+$cleanGroupUrl = urlencode($group);
 switch ($format) {
     case 'rss':
         header("Content-type: text/xml");
         echo '<?xml version="1.0" encoding="utf-8"?>' . "\n";?>
 <rss version="2.0">
  <channel> 
-  <title><?php echo $host; ?>: <?php echo $group?></title>
-  <link>http://<?php echo $host; ?>/group.php?group=<?php echo $group?></link>
+  <title><?php echo $cleanBaseHost; ?>: <?php echo $group?></title>
+  <link><?php echo $cleanBaseUrl; ?>/group.php?group=<?php echo $cleanGroupUrl?></link>
   <description></description>
         <?php
         break;
@@ -49,8 +52,8 @@ switch ($format) {
         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
         xmlns="http://my.netscape.com/rdf/simple/0.9/">
  <channel>
-  <title><?php echo $host; ?>: <?php echo $group?></title>
-  <link>http://<?php echo $host; ?>/group.php?group=<?php echo $group?></link>
+  <title><?php echo $cleanBaseHost; ?>: <?php echo $group?></title>
+  <link><?php echo $cleanBaseUrl; ?>/group.php?group=<?php echo $cleanGroupUrl?></link>
   <description><?php echo $group?> Newsgroup at <?php echo $NNTP_HOST; ?></description>
   <language>en-US</language>
  </channel>
@@ -146,11 +149,13 @@ $charset = "utf-8";
 foreach ($overview['articles'] as $articleNumber => $details) {
     /*  $date = date("H:i:s M/d/y", strtotime($odate)); */
     $date822 = date("r", strtotime($details['date']));
+    $cleanArticlePath = "/$cleanGroupUrl/" . urlencode((string) $articleNumber);
+    $cleanArticleLink = "$cleanBaseUrl$cleanArticlePath";
 
     switch ($format) {
         case 'rss':
             echo "  <item>\n";
-            echo "   <link>http://$host/$group/$articleNumber</link>\n";
+            echo "   <link>$cleanArticleLink</link>\n";
             echo "   <title>", format_subject($details['subject'], $charset), "</title>\n";
             echo "   <description>",
                 htmlspecialchars(format_author($details['author'], $charset), ENT_QUOTES, "UTF-8"),
@@ -161,7 +166,7 @@ foreach ($overview['articles'] as $articleNumber => $details) {
         case 'rdf':
             echo " <item>\n";
             echo "  <title>", format_subject($details['subject'], $charset), "</title>\n";
-            echo "  <link>http://$host/$group/$articleNumber</link>\n";
+            echo "  <link>$cleanArticleLink</link>\n";
             echo "  <description>",
                 htmlspecialchars(format_author($details['author'], $charset), ENT_QUOTES, "UTF-8"),
                 "</description>\n";

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ try {
 
 head();
 
-$DISPLAY_NNTP_HOST = htmlspecialchars(($NNTP_HOST == 'localhost') ? 'news.php.net' : $NNTP_HOST);
+$DISPLAY_NNTP_HOST = htmlspecialchars(($NNTP_HOST == 'localhost') ? 'news-web.php.net' : $NNTP_HOST);
 ?>
 
 <nav class="secondary-nav">

--- a/lib/config.php
+++ b/lib/config.php
@@ -4,3 +4,10 @@ $NNTP_HOST = 'localhost';
 if (getenv('NNTP_HOST')) {
     $NNTP_HOST = getenv('NNTP_HOST');
 }
+
+$NEWS_WEB_BASE_URL = 'https://news.php.net';
+if (getenv('NEWS_WEB_BASE_URL')) {
+    $NEWS_WEB_BASE_URL = rtrim(getenv('NEWS_WEB_BASE_URL'), '/');
+} elseif (PHP_SAPI == 'cli-server') {
+    $NEWS_WEB_BASE_URL = 'http://' . $_SERVER['HTTP_HOST'];
+}

--- a/lib/config.php
+++ b/lib/config.php
@@ -5,7 +5,7 @@ if (getenv('NNTP_HOST')) {
     $NNTP_HOST = getenv('NNTP_HOST');
 }
 
-$NEWS_WEB_BASE_URL = 'https://news.php.net';
+$NEWS_WEB_BASE_URL = 'https://news-web.php.net';
 if (getenv('NEWS_WEB_BASE_URL')) {
     $NEWS_WEB_BASE_URL = rtrim(getenv('NEWS_WEB_BASE_URL'), '/');
 } elseif (PHP_SAPI == 'cli-server') {


### PR DESCRIPTION
Private fork follow up. Uses the configured base URL for RSS/RDF links instead of the request host header.