### PR TITLE
Corrected NNTP_HOST in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ for local development.
 ```
 git clone https://github.com/php/web-news.git
 cd web-news/
-NNTP_HOST=news-web.php.net php -S localhost:8080 .router.php
+NNTP_HOST=news.php.net php -S localhost:8080 .router.php
 ```
 
 -----


### PR DESCRIPTION
Apparently, I misunderstood the review comment.

ref: https://github.com/php/web-news/pull/41#issuecomment-5243478757 @jimwins

> The change in README.md is not correct, news.php.net is still the correct NNTP_HOST, it's the NEWS_WEB_BASE_URL that needs to be news-web.php.net.

